### PR TITLE
the UttpToHttpGateway.Client now supports .net 8 (instead of requiring 9)

### DIFF
--- a/UdpToHttpGateway/UdpToHttpGateway.Client/UdpToHttpGateway.Client.csproj
+++ b/UdpToHttpGateway/UdpToHttpGateway.Client/UdpToHttpGateway.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/UdpToHttpGateway.Tests.csproj
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/UdpToHttpGateway.Tests.csproj
@@ -19,6 +19,6 @@
 	  <FrameworkReference Include="Microsoft.AspNetCore.App" />	  
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\UdpToHttpGateway.Messages\UdpToHttpGateway.Client.csproj" />
+    <ProjectReference Include="..\UdpToHttpGateway.Client\UdpToHttpGateway.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/UdpToHttpGateway/UdpToHttpGateway/Program.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway/Program.cs
@@ -2,6 +2,7 @@ using UdpToHttpGateway;
 
 HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
 builder.Services.Configure<GatewayOptions>(builder.Configuration.GetRequiredSection(nameof(GatewayOptions)));
+builder.Services.AddSystemd();
 builder.Services.AddHostedService<UdpReceiver>();
 
 builder.Build().Run();

--- a/UdpToHttpGateway/UdpToHttpGateway/UdpToHttpGateway.csproj
+++ b/UdpToHttpGateway/UdpToHttpGateway/UdpToHttpGateway.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -17,6 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0-preview.6.24327.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Systemd" Version="9.0.0-preview.6.24327.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+    <Content Include="*.sh;*.service" CopyToOutputDirectory="Always" ExcludeFromSingleFile="true" />
   </ItemGroup>
 </Project>

--- a/UdpToHttpGateway/UdpToHttpGateway/configure.sh
+++ b/UdpToHttpGateway/UdpToHttpGateway/configure.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -eu
+trap 'echo -e "\033[1;31mScript failed (line $LINENO)!\033[0m"' ERR #general error message in case of error
+
+cp *.service /etc/systemd/system
+mkdir -p /usr/local/sbin/udptohttpgateway
+rm -f /usr/local/sbin/udptohttpgateway/UdpToHttpGateway #we explicitely remove to avoid cp of the service failing if its already running
+cp UdpToHttpGateway /usr/local/sbin/udptohttpgateway
+cp UdpToHttpGateway.dbg /usr/local/sbin/udptohttpgateway
+cp appsettings.json /usr/local/sbin/udptohttpgateway
+chmod +x /usr/local/sbin/udptohttpgateway/UdpToHttpGateway
+systemctl daemon-reload
+sudo systemctl start udptohttpgateway.service
+sudo systemctl enable udptohttpgateway.service

--- a/UdpToHttpGateway/UdpToHttpGateway/udptohttpgateway.service
+++ b/UdpToHttpGateway/UdpToHttpGateway/udptohttpgateway.service
@@ -1,0 +1,10 @@
+﻿[Unit]
+Description=Udp to Http Gateway
+
+[Service]
+Type=notify
+WorkingDirectory=/usr/local/sbin/udptohttpgateway
+ExecStart=/usr/local/sbin/udptohttpgateway/UdpToHttpGateway
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Also:

* fixed an issue with the test project reference after folder renames in the initial PR.
* added configure.sh to run as a systemd service (tested on debian)