### PR TITLE
working github build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,63 @@
+###############################################################################
+# Set default behavior to automatically normalize line endings.
+###############################################################################
+* text=auto eol=lf
+
+###############################################################################
+# Set default behavior for command prompt diff.
+#
+# This is need for earlier builds of msysgit that does not have it on by
+# default for csharp files.
+# Note: This is only used by command line
+###############################################################################
+#*.cs     diff=csharp
+
+###############################################################################
+# Set the merge driver for project and solution files
+#
+# Merging from the command prompt will add diff markers to the files if there
+# are conflicts (Merging from VS is not affected by the settings below, in VS
+# the diff markers are never inserted). Diff markers may cause the following 
+# file extensions to fail to load in VS. An alternative would be to treat
+# these files as binary and thus will always conflict and require user
+# intervention with every merge. To do so, just uncomment the entries below
+###############################################################################
+#*.sln       merge=binary
+#*.csproj    merge=binary
+#*.vbproj    merge=binary
+#*.vcxproj   merge=binary
+#*.vcproj    merge=binary
+#*.dbproj    merge=binary
+#*.fsproj    merge=binary
+#*.lsproj    merge=binary
+#*.wixproj   merge=binary
+#*.modelproj merge=binary
+#*.sqlproj   merge=binary
+#*.wwaproj   merge=binary
+
+###############################################################################
+# behavior for image files
+#
+# image files are treated as binary by default.
+###############################################################################
+#*.jpg   binary
+#*.png   binary
+#*.gif   binary
+
+###############################################################################
+# diff behavior for common document formats
+# 
+# Convert binary document formats to text before diffing them. This feature
+# is only available from the command line. Turn it on by uncommenting the 
+# entries below.
+###############################################################################
+#*.doc   diff=astextplain
+#*.DOC   diff=astextplain
+#*.docx  diff=astextplain
+#*.DOCX  diff=astextplain
+#*.dot   diff=astextplain
+#*.DOT   diff=astextplain
+#*.pdf   diff=astextplain
+#*.PDF   diff=astextplain
+#*.rtf   diff=astextplain
+#*.RTF   diff=astextplain

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -22,7 +22,7 @@ jobs:
     # https://docs.docker.com/build/ci/github-actions/export-docker/
     # https://docs.docker.com/build/ci/github-actions/cache/#github-cache
     # https://docs.docker.com/build/ci/github-actions/reproducible-builds/
-    runs-on: ubuntu-latest
+    runs-on: linux-arm64
 
     services:
       registry:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -59,7 +59,7 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
           target: publish
-          tags: localregistry:5000/udptohttpgateway/app:publish
+          tags: localhost:5000/udptohttpgateway/app:publish
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test
@@ -70,7 +70,7 @@ jobs:
           cache-from: type=gha
           no-cache: true
           build-args:
-            BASE_IMAGE=localregistry:5000/udptohttpgateway/app:publish
+            BASE_IMAGE=localhost:5000/udptohttpgateway/app:publish
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          outputs: "--output=type=docker"
+          outputs: "--output=type=cache-only"
           cache-from: type=gha
           no-cache: true
           build-args:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -49,8 +49,8 @@ jobs:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
-          target: publish
-          tags: localhost:5000/udptohttpgateway:publish
+          target: testbase
+          tags: localhost:5000/udptohttpgateway:testbase
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test
@@ -62,7 +62,7 @@ jobs:
           cache-from: type=gha
           no-cache: true
           build-args:
-            TEST_BASE_IMAGE=localhost:5000/udptohttpgateway:publish
+            TEST_BASE_IMAGE=localhost:5000/udptohttpgateway:testbase
       - name: Login to Container registry Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -14,6 +14,7 @@ env:
   IMAGE_NAME: ${{ github.repository }}
   TEST_TAG: user/app:test
   SOURCE_DATE_EPOCH: 0
+  DOCKERD_ROOTLESS_ROOTLESSKIT_DISABLE_HOST_LOOPBACK: false # see comment at https://stackoverflow.com/a/74979409/66372
 
 jobs:
   docker:
@@ -65,7 +66,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp&
+            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp --add-host=host.docker.internal:host-gateway&
             # docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -d -p 4280:4280/udp&
+            docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp&
             dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push
         id: buildandpush

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          tags: localhost:5000/udptohttpgateway:test
           cache-from: type=gha
           no-cache: true
           build-args:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -61,7 +61,7 @@ jobs:
           cache-from: type=gha
           no-cache: true
           build-args:
-            TEST_BASE_IMAGE=localhost:5000/caudptohttpgateway:publish
+            TEST_BASE_IMAGE=localhost:5000/udptohttpgateway:publish
       - name: Login to Container registry Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -58,7 +58,6 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          outputs: "type=cache-only"
           cache-from: type=gha
           no-cache: true
           build-args:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp&
+            # docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp&
             docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
+          tags: localhost:5000/udptohttpgateway:test
           cache-from: type=gha
           no-cache: true
           build-args:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -13,7 +13,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   SOURCE_DATE_EPOCH: 0
-  TEST_TAG: local/app:test
+  TEST_TAG: udptohttpgateway:publish
 
 jobs:
   docker:
@@ -62,7 +62,6 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          target: publish
           # cache-from: type=gha
           no-cache: true
       - name: Build and push

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -54,7 +54,7 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           load: true
           target: publish
-          tags: ${{ TEST_TAG }}
+          tags: ${{ env.TEST_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            # docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp&
-            docker run --rm ${{ env.TEST_TAG }} --network "host"&
+            docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp # --add-host=host.docker.internal:host-gateway&
+            #docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            #docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
+            # docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
             docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Publish to Azure blob
         run: |
           mkdir -p arm
-          docker cp $(docker create ${image} --platform linux/arm64):/app/* arm
+          docker cp $(docker create ${{steps.meta.outputs.tags}} --platform linux/arm64):/app/* arm
           cd arm
           zip -r udptohttpgateway.zip *
           curl -f -X PUT -H "x-ms-version: 2020-04-08" -H "Content-Type: application/octet-stream" -H "x-ms-blob-type: BlockBlob" \

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
+          outputs: "--output=type=docker"
           cache-from: type=gha
           no-cache: true
           build-args:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -41,6 +41,16 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db #3.6.1
+      - name: Initial build for testing
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
+        with:
+          context: "./UdpToHttpGateway"
+          file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
+          push: true
+          target: publish
+          tags: localhost:5000/udptohttpgateway/app:publish
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Login to Container registry Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:
@@ -52,16 +62,6 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Initial build for testing
-        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
-        with:
-          context: "./UdpToHttpGateway"
-          file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
-          push: true
-          target: publish
-          tags: localhost:5000/udptohttpgateway/app:publish
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
       - name: Run test
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      registry:
+      localregistry:
         image: registry:2
         ports:
           - 5000:5000
@@ -59,7 +59,7 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
           target: publish
-          tags: localhost:5000/udptohttpgateway/app:publish
+          tags: localregistry:5000/udptohttpgateway/app:publish
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test
@@ -70,7 +70,7 @@ jobs:
           cache-from: type=gha
           no-cache: true
           build-args:
-            BASE_IMAGE=localhost:5000/udptohttpgateway/app:publish
+            BASE_IMAGE=localregistry:5000/udptohttpgateway/app:publish
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -68,7 +68,7 @@ jobs:
             # docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp&
             docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
-            dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min
+            dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          outputs: "--output=type=cache-only"
+          outputs: "type=cache-only"
           cache-from: type=gha
           no-cache: true
           build-args:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          # cache-from: type=gha
+          cache-from: type=gha
           no-cache: true
       - name: Build and push
         id: buildandpush

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -92,6 +92,3 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.buildandpush.outputs.digest }}
           push-to-registry: true
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp # --add-host=host.docker.internal:host-gateway&
+            docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
             #docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -66,6 +66,8 @@ jobs:
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
             docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp&
+            docker run --rm ${{ env.TEST_TAG }} --network "host"&
+            #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push
         id: buildandpush

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      localregistry:
+      registry:
         image: registry:2
         ports:
           - 5000:5000
@@ -41,6 +41,8 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db #3.6.1
+        with:
+          driver-opts: network=host
       - name: Initial build for testing
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
@@ -48,9 +50,18 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
           target: publish
-          tags: localhost:5000/udptohttpgateway/app:publish
+          tags: localhost:5000/udptohttpgateway/app:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Run test
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
+        with:
+          context: "./UdpToHttpGateway"
+          file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
+          cache-from: type=gha
+          no-cache: true
+          build-args:
+            BASE_IMAGE=localhost:5000/udptohttpgateway/app:latest
       - name: Login to Container registry Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:
@@ -62,15 +73,6 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Run test
-        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
-        with:
-          context: "./UdpToHttpGateway"
-          file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
-          cache-from: type=gha
-          no-cache: true
-          build-args:
-            BASE_IMAGE=localhost:5000/udptohttpgateway/app:publish
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
-            #docker run --rm ${{ env.TEST_TAG }} --network "host"&
+            #docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
+            docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -11,7 +11,7 @@ on:
         - main
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: udptohttpgateway
   SOURCE_DATE_EPOCH: 0
 
 jobs:
@@ -75,7 +75,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push
         id: buildandpush
-        # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
           platforms: linux/amd64,linux/arm64
@@ -92,3 +91,12 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
           subject-digest: ${{ steps.buildandpush.outputs.digest }}
           push-to-registry: true
+      - name: Publish to Azure blob
+        run: |
+          mkdir -p arm
+          docker cp $(docker create ${image} --platform linux/arm64):/app/* arm
+          cd arm
+          zip -r udptohttpgateway.zip *
+          curl -f -X PUT -H "x-ms-version: 2020-04-08" -H "Content-Type: application/octet-stream" -H "x-ms-blob-type: BlockBlob" \
+            "${{ vars.BLOB_URL }}/udptohttpgateway-${{ steps.meta.outputs.version }}.zip${{secrets.BLOB_QUERYSTRING}}" \
+            --upload-file 'udptohttpgateway.zip'

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -30,11 +30,11 @@ jobs:
         ports:
           - 5000:5000
 
-    # permissions:
-    #   contents: read
-    #   packages: write
-    #   attestations: write
-    #   id-token: write
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -50,7 +50,7 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
           target: publish
-          tags: localhost:5000/udptohttpgateway/app:latest
+          tags: localhost:5000/udptohttpgateway:publish
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test
@@ -61,7 +61,7 @@ jobs:
           cache-from: type=gha
           no-cache: true
           build-args:
-            BASE_IMAGE=localhost:5000/udptohttpgateway/app:latest
+            TEST_BASE_IMAGE=localhost:5000/caudptohttpgateway:publish
       - name: Login to Container registry Hub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -59,7 +59,7 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
           target: publish
-          tags: localhost:5000/udptohttpgateway:publish
+          tags: localhost:5000/udptohttpgateway/app:publish
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test
@@ -70,7 +70,7 @@ jobs:
           cache-from: type=gha
           no-cache: true
           build-args:
-            BASE_IMAGE=localhost:5000/udptohttpgateway:publish
+            BASE_IMAGE=localhost:5000/udptohttpgateway/app:publish
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -94,4 +94,4 @@ jobs:
           push-to-registry: true
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -12,9 +12,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TEST_TAG: user/app:test
   SOURCE_DATE_EPOCH: 0
-  DOCKERD_ROOTLESS_ROOTLESSKIT_DISABLE_HOST_LOOPBACK: false # see comment at https://stackoverflow.com/a/74979409/66372
+  TEST_TAG: local/app:test
 
 jobs:
   docker:
@@ -48,28 +47,24 @@ jobs:
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 #v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      - name: Build and export to docker
-        id: push
+      - name: Initial build for testing
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           load: true
-          tags: ${{ env.TEST_TAG }}
-          labels: ${{ steps.meta.outputs.labels }}
+          target: publish
+          tags: ${{ TEST_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-      - name: Setup .NET (for the test)
-        uses: actions/setup-dotnet@v4
+      - name: Run test
+        uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
-          dotnet-version: '8.0.x'
-      - name: Test
-        working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
-        run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp --add-host=host.docker.internal:host-gateway&
-            # docker run --rm ${{ env.TEST_TAG }} --network "host"&
-            #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
-            dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min
+          context: "./UdpToHttpGateway"
+          file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
+          target: publish
+          # cache-from: type=gha
+          no-cache: true
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -64,7 +64,7 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Test
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -d -p 4280:4280/udp
+            docker run --rm ${{ env.TEST_TAG }} -d -p 4280:4280/udp&
             dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push
         id: buildandpush

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -63,7 +63,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Test
-        working-directory: "./UdpToHttpGateway"
+        working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
             docker run --rm ${{ env.TEST_TAG }} -d -p 4280:4280/udp&
             dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
+            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp --add-host=host.docker.internal:host-gateway&
             # docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Test
+        working-directory: "./UdpToHttpGateway"
         run: |
             docker run --rm ${{ env.TEST_TAG }} -d -p 4280:4280/udp&
             dotnet test -c Release --verbosity normal --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Publish to Azure blob
         run: |
           mkdir -p arm
-          docker cp $(docker create ${{steps.meta.outputs.tags}} --platform linux/arm64):/app arm
+          docker cp $(docker create ${{steps.meta.outputs.tags}} --platform=linux/arm64):/app arm
           cd arm/app
           zip -r udptohttpgateway.zip *
           curl -f -X PUT -H "x-ms-version: 2020-04-08" -H "Content-Type: application/octet-stream" -H "x-ms-blob-type: BlockBlob" \

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            # docker run --rm ${{ env.TEST_TAG }} -p 4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
-            docker run --rm ${{ env.TEST_TAG }} --network "host"&
+            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp& # --add-host=host.docker.internal:host-gateway&
+            # docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min
       - name: Build and push

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp --add-host=host.docker.internal:172.17.0.1&
+            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp&
             # docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -13,7 +13,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
   SOURCE_DATE_EPOCH: 0
-  TEST_TAG: udptohttpgateway:publish
 
 jobs:
   docker:
@@ -24,6 +23,12 @@ jobs:
     # https://docs.docker.com/build/ci/github-actions/cache/#github-cache
     # https://docs.docker.com/build/ci/github-actions/reproducible-builds/
     runs-on: ubuntu-latest
+
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     permissions:
       contents: read
@@ -52,9 +57,9 @@ jobs:
         with:
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
-          load: true
+          push: true
           target: publish
-          tags: ${{ env.TEST_TAG }}
+          tags: localhost:5000/udptohttpgateway:publish
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Run test
@@ -64,6 +69,8 @@ jobs:
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
           cache-from: type=gha
           no-cache: true
+          build-args:
+            BASE_IMAGE=localhost:5000/udptohttpgateway:publish
       - name: Build and push
         id: buildandpush
         # if: ${{ startswith(github.ref, 'refs/tags')}} # only push tags? startswith(github.ref, 'refs/tags')

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -30,11 +30,11 @@ jobs:
         ports:
           - 5000:5000
 
-    permissions:
-      contents: read
-      packages: write
-      attestations: write
-      id-token: write
+    # permissions:
+    #   contents: read
+    #   packages: write
+    #   attestations: write
+    #   id-token: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Test
         working-directory: "./UdpToHttpGateway/UdpToHttpGateway.Tests"
         run: |
-            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp --add-host=host.docker.internal:host-gateway&
+            docker run --rm ${{ env.TEST_TAG }} -p 0.0.0.0:4280:4280/udp --add-host=host.docker.internal:172.17.0.1&
             # docker run --rm ${{ env.TEST_TAG }} --network "host"&
             #TODO: we might want a pause before moving forward below ... also run the app with debug conf to get more info
             dotnet test -c Release --blame --blame-hang --blame-hang-timeout 10min

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -77,7 +77,7 @@ jobs:
         id: buildandpush
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -94,8 +94,8 @@ jobs:
       - name: Publish to Azure blob
         run: |
           mkdir -p arm
-          docker cp $(docker create ${{steps.meta.outputs.tags}} --platform linux/arm64):/app/* arm
-          cd arm
+          docker cp $(docker create ${{steps.meta.outputs.tags}} --platform linux/arm64):/app arm
+          cd arm/app
           zip -r udptohttpgateway.zip *
           curl -f -X PUT -H "x-ms-version: 2020-04-08" -H "Content-Type: application/octet-stream" -H "x-ms-blob-type: BlockBlob" \
             "${{ vars.BLOB_URL }}/udptohttpgateway-${{ steps.meta.outputs.version }}.zip${{secrets.BLOB_QUERYSTRING}}" \

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -11,7 +11,7 @@ on:
         - main
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: udptohttpgateway
+  IMAGE_NAME: ${{ github.repository }}
   SOURCE_DATE_EPOCH: 0
 
 jobs:

--- a/.github/workflows/udptohttpgateway.yml
+++ b/.github/workflows/udptohttpgateway.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Initial build for testing
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
+          platforms: linux/arm64
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway/Dockerfile"
           push: true
@@ -56,6 +57,7 @@ jobs:
       - name: Run test
         uses: docker/build-push-action@5cd11c3a4ced054e52742c5fd54dca954e0edd85 #v6.7.0
         with:
+          platforms: linux/arm64
           context: "./UdpToHttpGateway"
           file: "./UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile"
           cache-from: type=gha

--- a/UdpToHttpGateway/.editorconfig
+++ b/UdpToHttpGateway/.editorconfig
@@ -25,6 +25,9 @@ csharp_style_expression_bodied_operators = false:silent
 csharp_style_expression_bodied_properties = true:silent
 csharp_style_expression_bodied_indexers = true:silent
 csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+dotnet_diagnostic.IDE0040.severity = error
 
 [*.{cs,vb}]
 #### Naming styles ####

--- a/UdpToHttpGateway/.editorconfig
+++ b/UdpToHttpGateway/.editorconfig
@@ -76,4 +76,4 @@ dotnet_naming_style.pascal_case.capitalization = pascal_case
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
-end_of_line = crlf
+end_of_line = lf

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
@@ -1,3 +1,5 @@
+ARG TEST_BASE_IMAGE=udptohttpgateway:publish
+
 FROM udptohttpgateway:publish AS test
 ARG TARGETARCH
 WORKDIR /src

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
@@ -1,9 +1,7 @@
-ARG TEST_BASE_IMAGE=udptohttpgateway:publish
+ARG TEST_BASE_IMAGE=udptohttpgateway:testbase
 
 FROM ${TEST_BASE_IMAGE} AS test
+ARG BUILD_CONFIGURATION=Release
 ARG TARGETARCH
-WORKDIR /src
-#copying the rest of files to get the tests and dependencies
-COPY . . 
-RUN cd /app/publish && (./UdpToHttpGateway&) && cd /src/UdpToHttpGateway.Tests && \
-    dotnet test -a $TARGETARCH -c $BUILD_CONFIGURATION --blame --blame-hang --blame-hang-timeout 10min
+RUN { cd /app/publish && ./UdpToHttpGateway& } && \
+    dotnet test -a $TARGETARCH -c $BUILD_CONFIGURATION --no-build --no-restore --blame --blame-hang --blame-hang-timeout 10min

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
@@ -1,6 +1,6 @@
 ARG TEST_BASE_IMAGE=udptohttpgateway:publish
 
-FROM udptohttpgateway:publish AS test
+FROM ${TEST_BASE_IMAGE} AS test
 ARG TARGETARCH
 WORKDIR /src
 #copying the rest of files to get the tests and dependencies

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/Dockerfile
@@ -1,0 +1,7 @@
+FROM udptohttpgateway:publish AS test
+ARG TARGETARCH
+WORKDIR /src
+#copying the rest of files to get the tests and dependencies
+COPY . . 
+RUN cd /app/publish && (./UdpToHttpGateway&) && cd /src/UdpToHttpGateway.Tests && \
+    dotnet test -a $TARGETARCH -c $BUILD_CONFIGURATION --blame --blame-hang --blame-hang-timeout 10min

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/Properties/launchSettings.json
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "UdpToHttpGateway.Tests": {
+      "commandName": "Project"
+    },
+    "Container (Dockerfile)": {
+      "commandName": "Docker"
+    }
+  }
+}

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -27,7 +27,7 @@ public class RequestsTest
     {
         IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
         testIp = addresses.First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
-        context?.WriteLine($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}");
+        throw new NotSupportedException($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}. test ip: {testIp}");
     }
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -209,7 +209,7 @@ public class RequestsTest
         writer.Write(request.Method);
         writer.Write(SPACE + request.GetDisplayUrl());
         writer.Write(SPACE + request.Protocol);
-        writer.Write("\r\n");
+        writer.Write("\n");
     }
 
     static void WriteHeaders(HttpRequest request, StringWriter writer)
@@ -217,10 +217,10 @@ public class RequestsTest
         foreach (KeyValuePair<string, Microsoft.Extensions.Primitives.StringValues> kvp in request.Headers)
         {
             writer.Write(string.Format("{0}: {1}", kvp.Key, kvp.Value));
-            writer.Write("\r\n");
+            writer.Write("\n");
         }
 
-        writer.Write("\r\n");
+        writer.Write("\n");
     }
 }
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -25,7 +25,7 @@ public class RequestsTest
     public Task TestRootGetRequest() => TestRequest(HttpMethod.Get, "/", default(byte[]?), $"""
  GET http://{TestAddress}:{HttpPort}/ HTTP/1.1
  Host: {TestAddress}:{HttpPort}
- .
+ 
 
  """);
 

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -27,6 +27,7 @@ public class RequestsTest
     {
         IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
         testIp = addresses.First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
+        Console.WriteLine($"detected addresses: {string.Join(',', addresses)}");
     }
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -18,7 +18,7 @@ public class RequestsTest
 {
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
-    const string TestAddress = "172.17.0.1";
+    const string TestAddress = "host.docker.internal";
     static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("172.17.0.3:4280");
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -18,7 +18,7 @@ public class RequestsTest
 {
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
-    const string TestAddress = "host.docker.internal";
+    const string TestAddress = "172.17.0.1";
     static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("172.17.0.3:4280");
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -27,7 +27,7 @@ public class RequestsTest
     {
         IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
         testIp = addresses.First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
-        Console.WriteLine($"detected addresses: {string.Join(',', addresses)}");
+        Console.WriteLine($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}");
     }
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -23,11 +23,11 @@ public class RequestsTest
     static IPAddress? testIp;
 
     [ClassInitialize]
-    public static async Task Initialize(TestContext _)
+    public static async Task Initialize(TestContext context)
     {
         IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
         testIp = addresses.First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
-        Console.WriteLine($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}");
+        context?.WriteLine($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}");
     }
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -19,7 +19,7 @@ public class RequestsTest
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
     const string TestAddress = "host.docker.internal";
-    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("::1:4280");
+    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");
 
     [TestMethod]
     public Task TestRootGetRequest() => TestRequest(HttpMethod.Get, "/", default(byte[]?), $"""

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -19,7 +19,7 @@ public class RequestsTest
 {
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
-    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");
+    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("172.17.0.3:4280");
     static string testIp;
 
     [ClassInitialize]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -16,7 +16,7 @@ namespace UdpToHttpGateway.Tests;
 public class RequestsTest
 #pragma warning restore CA1515 // Consider making public types internal
 {
-    const int RequestTimeout = 100;
+    const int RequestTimeout = 300;
     const int HttpPort = 9080;
     const string TestAddress = "127.0.0.1";
     static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -19,7 +19,7 @@ public class RequestsTest
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
     const string TestAddress = "host.docker.internal";
-    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");
+    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("172.17.0.3:4280");
 
     [TestMethod]
     public Task TestRootGetRequest() => TestRequest(HttpMethod.Get, "/", default(byte[]?), $"""

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -16,16 +16,16 @@ namespace UdpToHttpGateway.Tests;
 public class RequestsTest
 #pragma warning restore CA1515 // Consider making public types internal
 {
-    const int RequestTimeout = 1000;
+    const int RequestTimeout = 100;
     const int HttpPort = 9080;
-    const string TestAddress = "host.docker.internal";
-    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("172.17.0.3:4280");
+    const string TestAddress = "127.0.0.1";
+    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");
 
     [TestMethod]
     public Task TestRootGetRequest() => TestRequest(HttpMethod.Get, "/", default(byte[]?), $"""
  GET http://{TestAddress}:{HttpPort}/ HTTP/1.1
  Host: {TestAddress}:{HttpPort}
-
+ 
 
  """);
 

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -25,7 +25,7 @@ public class RequestsTest
     public Task TestRootGetRequest() => TestRequest(HttpMethod.Get, "/", default(byte[]?), $"""
  GET http://{TestAddress}:{HttpPort}/ HTTP/1.1
  Host: {TestAddress}:{HttpPort}
- 
+ .
 
  """);
 

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -26,8 +26,8 @@ public class RequestsTest
     public static async Task Initialize(TestContext context)
     {
         IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
-        testIp = addresses.First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
-        throw new NotSupportedException($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}. test ip: {testIp}");
+        testIp = addresses.Skip(1).First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
+        //throw new NotSupportedException($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}. test ip: {testIp}");
     }
 
     [TestMethod]

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -20,13 +20,14 @@ public class RequestsTest
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
     static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");
-    static IPAddress? testIp;
+    static string testIp;
 
     [ClassInitialize]
     public static async Task Initialize(TestContext context)
     {
-        IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
-        testIp = addresses.Skip(1).First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
+        //IPAddress[] addresses = await Dns.GetHostAddressesAsync(string.Empty, AddressFamily.InterNetwork).ConfigureAwait(false);
+        //testIp = addresses.Skip(1).First(a => a.AddressFamily == AddressFamily.InterNetwork && !IPAddress.IsLoopback(a));
+        testIp = "localhost";
         //throw new NotSupportedException($"detected addresses: {string.Join(',', addresses.Select(a => a.ToString()))}. test ip: {testIp}");
     }
 

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/RequestsTest.cs
@@ -19,7 +19,7 @@ public class RequestsTest
     const int RequestTimeout = 1000;
     const int HttpPort = 9080;
     const string TestAddress = "host.docker.internal";
-    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("127.0.0.1:4280");
+    static readonly IPEndPoint GatewayIp = IPEndPoint.Parse("::1:4280");
 
     [TestMethod]
     public Task TestRootGetRequest() => TestRequest(HttpMethod.Get, "/", default(byte[]?), $"""

--- a/UdpToHttpGateway/UdpToHttpGateway.Tests/UdpToHttpGateway.Tests.csproj
+++ b/UdpToHttpGateway/UdpToHttpGateway.Tests/UdpToHttpGateway.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSTest.Sdk/3.4.1">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <InvariantGlobalization>true</InvariantGlobalization>

--- a/UdpToHttpGateway/UdpToHttpGateway/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway/Dockerfile
@@ -10,7 +10,6 @@ FROM mcr.microsoft.com/dotnet/runtime:9.0-preview-bookworm-slim AS base
 USER app
 WORKDIR /app
 
-
 # This stage is used to build the service project
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim-amd64 AS build
 ARG TARGETARCH
@@ -21,9 +20,15 @@ RUN dpkg --add-architecture arm64 \
     clang zlib1g-dev zlib1g-dev:arm64 gcc-aarch64-linux-gnu llvm
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
-COPY ["UdpToHttpGateway/UdpToHttpGateway.csproj", "UdpToHttpGateway/"]
-RUN dotnet restore "./UdpToHttpGateway/UdpToHttpGateway.csproj" -a $TARGETARCH
-COPY . .
+#restoring first means the last restore is reused as long as the csproj files don't change
+COPY *.sln ./
+COPY ./UdpToHttpGateway/*.csproj ./UdpToHttpGateway/
+COPY ./UdpToHttpGateway.Tests/*.csproj ./UdpToHttpGateway.Tests/
+COPY ./UdpToHttpGateway.Client/*.csproj ./UdpToHttpGateway.Client/
+RUN dotnet restore
+#we only copy the project folders so changes to tests don't trigger a rebuild
+COPY .editorconfig .
+COPY UdpToHttpGateway UdpToHttpGateway
 WORKDIR "/src/UdpToHttpGateway"
 RUN dotnet build "./UdpToHttpGateway.csproj" -c $BUILD_CONFIGURATION -a $TARGETARCH -o /app/build
 

--- a/UdpToHttpGateway/UdpToHttpGateway/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway/Dockerfile
@@ -11,7 +11,7 @@ USER app
 WORKDIR /app
 
 # This stage is used to build the service project
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim-amd64 AS build
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:9.0-preview-bookworm-slim AS build
 ARG TARGETARCH
 # Install clang/zlib1g-dev dependencies for publishing to native
 RUN dpkg --add-architecture arm64 \

--- a/UdpToHttpGateway/UdpToHttpGateway/Dockerfile
+++ b/UdpToHttpGateway/UdpToHttpGateway/Dockerfile
@@ -37,6 +37,14 @@ FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./UdpToHttpGateway.csproj" -a $TARGETARCH -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=true
 
+FROM publish AS testbase
+ARG BUILD_CONFIGURATION=Release
+WORKDIR /src
+#copying the rest of files to get the tests and dependencies
+COPY . . 
+WORKDIR ./UdpToHttpGateway.Tests
+RUN dotnet build ./UdpToHttpGateway.Tests.csproj -c $BUILD_CONFIGURATION -a $TARGETARCH
+
 # This stage is used as the base for the final stage when launching from VS to support debugging in regular mode (Default when not using the Debug configuration)
 FROM base AS aotdebug
 USER root

--- a/UdpToHttpGateway/UdpToHttpGateway/Properties/launchSettings.json
+++ b/UdpToHttpGateway/UdpToHttpGateway/Properties/launchSettings.json
@@ -9,7 +9,7 @@
     },
     "Container (Dockerfile)": {
       "commandName": "Docker",
-      "DockerfileRunArguments": "-p 4280:4280/udp"
+      "DockerfileRunArguments": "-p 4280:4280/udp --add-host=host.docker.internal:host-gateway"
     }
   },
   "$schema": "https://json.schemastore.org/launchsettings.json"

--- a/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
@@ -47,7 +47,10 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
                 if (succeeded && message != null)
                 {
                     HttpResponseMessage response = await client.SendAsync(message, stoppingToken).ConfigureAwait(false);
-                    LogSending(DateTimeOffset.UtcNow, response, message);
+                    if (!response.IsSuccessStatusCode)
+                        LogSendingError(DateTimeOffset.UtcNow, response, message);
+                    else
+                        LogSending(DateTimeOffset.UtcNow, response, message);
                 }
                 else
                     LogParsingError(DateTimeOffset.UtcNow, bytes);
@@ -81,6 +84,8 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
     [LoggerMessage(Level = LogLevel.Debug, Message = "{time} - received response {response} for message {message}.")]
     partial void LogSending(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected error sending {message}.")]
+    partial void LogSendingError(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - received response {response} for message {message}.")]
     partial void LogSendingError(DateTimeOffset time, HttpRequestMessage? message, Exception ex);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected parsing error sending {message}.")]
     partial void LogParsingError(DateTimeOffset time, Memory<byte> message);

--- a/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
@@ -48,7 +48,7 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
                 {
                     HttpResponseMessage response = await client.SendAsync(message, stoppingToken).ConfigureAwait(false);
                     if (!response.IsSuccessStatusCode)
-                        LogSendingError(DateTimeOffset.UtcNow, response, message);
+                        LogSendingFailure(DateTimeOffset.UtcNow, response, message);
                     else
                         LogSending(DateTimeOffset.UtcNow, response, message);
                 }
@@ -84,7 +84,7 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
     [LoggerMessage(Level = LogLevel.Debug, Message = "{time} - received response {response} for message {message}.")]
     partial void LogSending(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected error sending {message}.")]
-    partial void LogSendingError(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
+    partial void LogSendingFailure(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - received response {response} for message {message}.")]
     partial void LogSendingError(DateTimeOffset time, HttpRequestMessage? message, Exception ex);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected parsing error sending {message}.")]

--- a/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
@@ -48,7 +48,7 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
                 {
                     HttpResponseMessage response = await client.SendAsync(message, stoppingToken).ConfigureAwait(false);
                     if (!response.IsSuccessStatusCode)
-                        LogSendingFailure(DateTimeOffset.UtcNow, response, message);
+                        LogSendingError(DateTimeOffset.UtcNow, response, message);
                     else
                         LogSending(DateTimeOffset.UtcNow, response, message);
                 }
@@ -83,9 +83,9 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "{time} - received response {response} for message {message}.")]
     partial void LogSending(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
-    [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected error sending {message}.")]
-    partial void LogSendingFailure(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - received response {response} for message {message}.")]
+    partial void LogSendingError(DateTimeOffset time, HttpResponseMessage response, HttpRequestMessage message);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected error sending {message}.")]
     partial void LogSendingError(DateTimeOffset time, HttpRequestMessage? message, Exception ex);
     [LoggerMessage(Level = LogLevel.Warning, Message = "{time} - unexpected parsing error sending {message}.")]
     partial void LogParsingError(DateTimeOffset time, Memory<byte> message);

--- a/UdpToHttpGateway/UdpToHttpGateway/appsettings.json
+++ b/UdpToHttpGateway/UdpToHttpGateway/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Microsoft.Hosting.Lifetime": "Error"
     }
   },

--- a/UdpToHttpGateway/UdpToHttpGateway/appsettings.json
+++ b/UdpToHttpGateway/UdpToHttpGateway/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Microsoft.Hosting.Lifetime": "Error"
     }
   },

--- a/UdpToHttpGateway/UdpToHttpGateway/configure.sh
+++ b/UdpToHttpGateway/UdpToHttpGateway/configure.sh
@@ -9,5 +9,5 @@ cp UdpToHttpGateway.dbg /usr/local/sbin/udptohttpgateway
 cp appsettings.json /usr/local/sbin/udptohttpgateway
 chmod +x /usr/local/sbin/udptohttpgateway/UdpToHttpGateway
 systemctl daemon-reload
-sudo systemctl start udptohttpgateway.service
-sudo systemctl enable udptohttpgateway.service
+systemctl start udptohttpgateway.service
+systemctl enable udptohttpgateway.service

--- a/UdpToHttpGateway/UdpToHttpGateway/remove.sh
+++ b/UdpToHttpGateway/UdpToHttpGateway/remove.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -eu
+trap 'echo -e "\033[1;31mScript failed (line $LINENO)!\033[0m"' ERR #general error message in case of error
+
+systemctl stop udptohttpgateway.service
+systemctl disable udptohttpgateway.service
+rm /etc/systemd/system/udptohttpgateway.service
+rm -rf /usr/local/sbin/udptohttpgateway
+systemctl daemon-reload
+systemctl reset-failed


### PR DESCRIPTION
Note: for now we build specifically for arm64 Debian 12.

To download the latest pr build: `https://carelease.blob.core.windows.net/onewaygateway/udptohttpgateway-pr-prnumber.zip`

e.g. the build for this PR is at [https://carelease.blob.core.windows.net/onewaygateway/udptohttpgateway-pr-6.zip](https://carelease.blob.core.windows.net/onewaygateway/udptohttpgateway-pr-6.zip)

To enable the service in an arm 64 debian 12 device:

```
wget https://carelease.blob.core.windows.net/onewaygateway/udptohttpgateway-pr-6.zip && unzip udptohttpgateway-pr-6.zip -d udptohttpgateway && cd udptohttpgateway && chmod +x configure.sh
sudo ./configure.sh
```

The first line downloads and unpacks the app, and the second line installs it as a systemd service.

Additional notes on changes included in this PR:
- added .gitattributes + updated editor config to force lf line endings on checkout (avoids local build differences for string literals depending on settings used)
- moved to arm64 only build due to various issues, with the most important being the build grabbing the wrong image in the docker cp command
- added push to azure blob
- tests are ran within docker, avoiding issues on the server and client. Its also possible to run the tests from VS by changing the testaddress to host.docker.internal
- the test project has its own docker file so one can always use --no-cache with the tests, but still be able to use caching for the overall build (including tests)
- reduced the individual tests timeout to 300ms for faster feedback on failing tests
- improved docker layout for better caching
- added remove.sh to allow to remove the installed system service
- added more warning logging of failed requests