### PR TITLE
fixes crash on timeout and adds auto start on failures

### DIFF
--- a/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
+++ b/UdpToHttpGateway/UdpToHttpGateway/UdpReceiver.cs
@@ -89,6 +89,10 @@ sealed partial class UdpReceiver(IOptions<GatewayOptions> options, ILogger<UdpRe
                 message?.Dispose();
             }
         }
+        catch (OperationCanceledException ex)
+        {
+            LogSendingError(DateTimeOffset.UtcNow, message, ex);
+        }
         catch (HttpRequestException ex)
         {
             LogSendingError(DateTimeOffset.UtcNow, message, ex);

--- a/UdpToHttpGateway/UdpToHttpGateway/udptohttpgateway.service
+++ b/UdpToHttpGateway/UdpToHttpGateway/udptohttpgateway.service
@@ -5,6 +5,7 @@ Description=Udp to Http Gateway
 Type=notify
 WorkingDirectory=/usr/local/sbin/udptohttpgateway
 ExecStart=/usr/local/sbin/udptohttpgateway/UdpToHttpGateway
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
fixes crash on timeout and adds auto start on failures

The docs list timeout in 2 types of exceptions, so we were missing OperationCanceledException: https://learn.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.sendasync?view=net-9.0#system-net-http-httpclient-sendasync(system-net-http-httprequestmessage-system-threading-cancellationtoken)